### PR TITLE
Improve one common case for multiline diffing

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * Modified by Piotr Kaminski.
+ * Modified by Piotr Kaminski and Sergei Vorobev.
  */
 
 /**

--- a/diff.js
+++ b/diff.js
@@ -131,13 +131,21 @@ diff.prototype.diff_main = function(text1, text2, opt_checklines,
   var checklines = opt_checklines;
 
   // Trim off common prefix (speedup).
-  var commonlength = this.diff_commonPrefix(text1, text2);
+  if (checklines) {
+    var commonlength = this.diff_commonPrefix_newLine(text1, text2);
+  } else {
+    var commonlength = this.diff_commonPrefix(text1, text2);
+  }
   var commonprefix = text1.substring(0, commonlength);
   text1 = text1.substring(commonlength);
   text2 = text2.substring(commonlength);
 
   // Trim off common suffix (speedup).
-  commonlength = this.diff_commonSuffix(text1, text2);
+  if (checklines) {
+    commonlength = this.diff_commonSuffix_newLine(text1, text2);
+  } else {
+    commonlength = this.diff_commonSuffix(text1, text2);
+  }
   var commonsuffix = text1.substring(text1.length - commonlength);
   text1 = text1.substring(0, text1.length - commonlength);
   text2 = text2.substring(0, text2.length - commonlength);
@@ -570,6 +578,32 @@ diff.prototype.diff_commonPrefix = function(text1, text2) {
   return pointermid;
 };
 
+/**
+ * Determine the common prefix of two strings making delimitors only at new lines.
+ * @param {string} text1 First string.
+ * @param {string} text2 Second string.
+ * @return {number} The number of characters common to the start of each
+ *     string.
+ */
+ diff.prototype.diff_commonPrefix_newLine = function(text1, text2) {
+  var idx = this.diff_commonPrefix(text1, text2);
+  // special handling for the case when the whole string is matching
+  if (idx == text1.length && idx == text2.length) {
+    return idx;
+  }
+  if (idx == text1.length && text2[idx] == "\n") {
+    return idx
+  }
+  if (idx == text2.length && text1[idx] == "\n") {
+    return idx
+  }
+  var offset = text1.substring(0, idx).lastIndexOf("\n");
+  if (offset == -1) {
+    return 0;
+  }
+  return offset + 1;
+};
+
 
 /**
  * Determine the common suffix of two strings.
@@ -600,6 +634,31 @@ diff.prototype.diff_commonSuffix = function(text1, text2) {
     pointermid = Math.floor((pointermax - pointermin) / 2 + pointermin);
   }
   return pointermid;
+};
+
+/**
+ * Determine the common suffix of two strings making delimitors only at new lines.
+ * @param {string} text1 First string.
+ * @param {string} text2 Second string.
+ * @return {number} The number of characters common to the end of each string.
+ */
+ diff.prototype.diff_commonSuffix_newLine = function(text1, text2) {
+  var idx = this.diff_commonSuffix(text1, text2);
+  // special handling for the case when the whole string is matching
+  if (idx == text1.length && idx == text2.length) {
+    return idx;
+  }
+  if (idx == text1.length && text2[text2.length - idx - 1] == "\n") {
+    return idx
+  }
+  if (idx == text2.length && text1[text1.length - idx - 1] == "\n") {
+    return idx
+  }
+  var offset = text1.substring(text1.length - idx).indexOf("\n");
+  if (offset == -1) {
+    return 0;
+  }
+  return idx - offset;
 };
 
 

--- a/tests/diff_test.html
+++ b/tests/diff_test.html
@@ -86,7 +86,9 @@
 
       var tests = [
           'testDiffCommonPrefix',
+          'testDiffCommonPrefixNewLine',
           'testDiffCommonSuffix',
+          'testDiffCommonSuffixNewLine',
           'testDiffCommonOverlap',
           'testDiffHalfMatch',
           'testDiffLinesToChars',

--- a/tests/diff_test.js
+++ b/tests/diff_test.js
@@ -91,6 +91,22 @@ function testDiffCommonPrefix() {
   assertEquals(4, dmp.diff_commonPrefix('1234', '1234xyz'));
 }
 
+function testDiffCommonPrefixNewLine() {
+  // Detect any common prefix in repsect to new lines.
+  // Null case.
+  assertEquals(0, dmp.diff_commonPrefix_newLine('abc', 'abx'));
+
+  // Non-null case.
+  assertEquals(3, dmp.diff_commonPrefix_newLine('12\n34abcdef', '12\n34xyz'));
+
+  // Multiply \n case.
+  assertEquals(6, dmp.diff_commonPrefix_newLine('12\n34\n1abcdef', '12\n34\n1xyz'));
+
+  // Whole case.
+  assertEquals(4, dmp.diff_commonPrefix_newLine('1234', '1234\nxyz'));
+  assertEquals(0, dmp.diff_commonPrefix_newLine('1234', '12345\nxyz'));
+}
+
 function testDiffCommonSuffix() {
   // Detect any common suffix.
   // Null case.
@@ -101,6 +117,22 @@ function testDiffCommonSuffix() {
 
   // Whole case.
   assertEquals(4, dmp.diff_commonSuffix('1234', 'xyz1234'));
+}
+
+function testDiffCommonSuffixNewLine() {
+  // Detect any common suffix in respect to new lines.
+  // Null case.
+  assertEquals(0, dmp.diff_commonSuffix_newLine('abc', 'xbc'));
+
+  // Non-null case.
+  assertEquals(3, dmp.diff_commonSuffix_newLine('abcdef12\n34', 'xyz12\n34'));
+
+  // Multiply \n case.
+  assertEquals(6, dmp.diff_commonSuffix_newLine('abcdef1\n12\n34', 'xyz1\n12\n34'));
+
+  // Whole case.
+  assertEquals(4, dmp.diff_commonSuffix_newLine('1234', 'xyz\n1234'));
+  assertEquals(0, dmp.diff_commonSuffix_newLine('1234', 'xyz\n01234'));
 }
 
 function testDiffCommonOverlap() {
@@ -586,6 +618,11 @@ function testDiffMain() {
 
   // Large equality.
   assertEquivalent([[DIFF_INSERT, ' '], [DIFF_EQUAL, 'a'], [DIFF_INSERT, 'nd'], [DIFF_EQUAL, ' [[Pennsylvania]]'], [DIFF_DELETE, ' and [[New']], dmp.diff_main('a [[Pennsylvania]] and [[New', ' and [[Pennsylvania]]', false));
+
+  // Codifying a suboptimal but a technically correct diff
+  assertEquivalent([[DIFF_EQUAL, 'def x():\n    pass\n\ndef '], [DIFF_DELETE, 'y():\n    pass\n\ndef '], [DIFF_EQUAL, 'z():\n    pass\n']], dmp.diff_main('def x():\n    pass\n\ndef y():\n    pass\n\ndef z():\n    pass\n', 'def x():\n    pass\n\ndef z():\n    pass\n', false));
+  // Better diff when multiline heuristic is used
+  assertEquivalent([[DIFF_EQUAL, 'def x():\n    pass\n\n'], [DIFF_DELETE, 'def y():\n    pass\n\n'], [DIFF_EQUAL, 'def z():\n    pass\n']], dmp.diff_main('def x():\n    pass\n\ndef y():\n    pass\n\ndef z():\n    pass\n', 'def x():\n    pass\n\ndef z():\n    pass\n', true));
 
   // Timeout.
   dmp.Diff_Timeout = 0.1;  // 100ms

--- a/tests/speedtest.html
+++ b/tests/speedtest.html
@@ -20,7 +20,7 @@ function launch() {
   // No warmup loop since it risks triggering an 'unresponsive script' dialog
   // in client-side JavaScript
   var ms_start = (new Date()).getTime();
-  var d = dmp.diff_main(text1, text2, false);
+  var d = dmp.diff_main(text1, text2, true);
   var ms_end = (new Date()).getTime();
 
   var ds = dmp.diff_prettyHtml(d);


### PR DESCRIPTION
Addresses the following case:

```
def x():
    pass

def y():
    pass

def z():
    pass
```

```
def x():
    pass

def z():
    pass
```

Previously

<img width="102" alt="image" src="https://user-images.githubusercontent.com/816680/192126328-87a2c721-98be-47e0-a321-5412bf9c758f.png">



Now

<img width="138" alt="image" src="https://user-images.githubusercontent.com/816680/192126316-131158e4-9af2-4007-8bcf-dfde8ff90b27.png">

## Implementation
We piggy-back on the existing `diff_main` `opt_checklines` bool flag to make the common prefix and suffix heuristics respect this flag. Concretely they will only cut away the prefix/suffix that ends/starts with `\n`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reviewable/diff/1)
<!-- Reviewable:end -->
