### PR TITLE
Make second call to diff_cleanupSemantic inside the diff_lineMode_

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * Modified by Piotr Kaminski.
+ * Modified by Piotr Kaminski and Sergei Vorobev.
  */
 
 /**

--- a/diff.js
+++ b/diff.js
@@ -297,6 +297,9 @@ diff.prototype.diff_lineMode_ = function(text1, text2, deadline) {
   }
   diffs.pop();  // Remove the dummy entry at the end.
 
+  // Cleanup one more time after the rediff.
+  this.diff_cleanupSemantic(diffs);
+
   return diffs;
 };
 

--- a/tests/diff_test.html
+++ b/tests/diff_test.html
@@ -89,6 +89,7 @@
           'testDiffCommonSuffix',
           'testDiffCommonOverlap',
           'testDiffHalfMatch',
+          'testDiffLineMode',
           'testDiffLinesToChars',
           'testDiffCharsToLines',
           'testDiffCleanupMerge',

--- a/tests/diff_test.js
+++ b/tests/diff_test.js
@@ -305,6 +305,22 @@ function testDiffCleanupSemanticLossless() {
   diffs = [[DIFF_EQUAL, 'AAA\r\n\r\nBBB'], [DIFF_INSERT, '\r\nDDD\r\n\r\nBBB'], [DIFF_EQUAL, '\r\nEEE']];
   dmp.diff_cleanupSemanticLossless(diffs);
   assertEquivalent([[DIFF_EQUAL, 'AAA\r\n\r\n'], [DIFF_INSERT, 'BBB\r\nDDD\r\n\r\n'], [DIFF_EQUAL, 'BBB\r\nEEE']], diffs);
+  // Blank lines, next level
+  diffs = [
+    [DIFF_EQUAL, 'websites:\n'],
+    [DIFF_DELETE, 'name: ADP\nurl: https://www.adp.com\ntfa: No\n\n'],
+    [DIFF_EQUAL, 'name: Adirondack Insurance Exchange\nurl: http://www.aie-ny.com/\nimg: adirondackinsurnaceexchange.png\n'],
+    [DIFF_INSERT, 'tfa: No\n\nname: ADP\nurl: https://www.adp.com\n'],
+    [DIFF_EQUAL, 'tfa: No\n\nname: Credit Karma'],
+  ];
+  dmp.diff_cleanupSemanticLossless(diffs);
+  assertEquivalent([
+    [DIFF_EQUAL, 'websites:\n'],
+    [DIFF_DELETE, 'name: ADP\nurl: https://www.adp.com\ntfa: No\n\n'],
+    [DIFF_EQUAL, 'name: Adirondack Insurance Exchange\nurl: http://www.aie-ny.com/\nimg: adirondackinsurnaceexchange.png\ntfa: No\n\n'],
+    [DIFF_INSERT, 'name: ADP\nurl: https://www.adp.com\ntfa: No\n\n'],
+    [DIFF_EQUAL, 'name: Credit Karma'],
+  ], diffs);
 
   // Line boundaries.
   diffs = [[DIFF_EQUAL, 'AAA\r\nBBB'], [DIFF_INSERT, ' DDD\r\nBBB'], [DIFF_EQUAL, ' EEE']];
@@ -635,6 +651,20 @@ function testDiffMain() {
   }
 }
 
+function testDiffLineMode() {
+  // Test lines aligment (at the blank line border) in line-mode.
+  a = 'websites:\n    - name: ADP\n      url: https://www.adp.com\n      twitter: adp\n      img: adp.png\n      tfa: No\n\n    - name: Adirondack Insurance Exchange\n      url: http://www.aie-ny.com/\n      img: adirondackinsurnaceexchange.png\n      tfa: No\n\n    - name: Credit Karma\n      url: https://www.creditkarma.com\n      twitter: creditkarma';
+  b = 'websites:\n    - name: Adirondack Insurance Exchange\n      url: http://www.aie-ny.com/\n      img: adirondackinsurnaceexchange.png\n      tfa: No\n\n    - name: ADP\n      url: https://www.adp.com\n      twitter: adp\n      img: adp.png\n      tfa: No\n\n    - name: Credit Karma\n      url: https://www.creditkarma.com\n      twitter: creditkarma';
+  assertEquivalent(
+    [
+      [DIFF_EQUAL, 'websites:\n'],
+      [DIFF_DELETE, '    - name: ADP\n      url: https://www.adp.com\n      twitter: adp\n      img: adp.png\n      tfa: No\n\n'],
+      [DIFF_EQUAL, '    - name: Adirondack Insurance Exchange\n      url: http://www.aie-ny.com/\n      img: adirondackinsurnaceexchange.png\n      tfa: No\n\n'],
+      [DIFF_INSERT, '    - name: ADP\n      url: https://www.adp.com\n      twitter: adp\n      img: adp.png\n      tfa: No\n\n'],
+      [DIFF_EQUAL, '    - name: Credit Karma\n      url: https://www.creditkarma.com\n      twitter: creditkarma']
+    ], dmp.diff_lineMode_(a, b)
+  );
+}
 
 // MATCH TEST FUNCTIONS
 

--- a/tests/speedtest.html
+++ b/tests/speedtest.html
@@ -20,7 +20,7 @@ function launch() {
   // No warmup loop since it risks triggering an 'unresponsive script' dialog
   // in client-side JavaScript
   var ms_start = (new Date()).getTime();
-  var d = dmp.diff_main(text1, text2, false);
+  var d = dmp.diff_lineMode_(text1, text2);
   var ms_end = (new Date()).getTime();
 
   var ds = dmp.diff_prettyHtml(d);


### PR DESCRIPTION
Improve the case presented in https://github.com/Reviewable/Reviewable/issues/326#issuecomment-235714216

Concretely there is already a sequence of calls

`diff_lineMode_ -> diff_cleanupSemantic -> diff_cleanupSemanticLossless`

which performs the optimal alignment for deletes and adds based on the `diff_cleanupSemanticScore_` function.
However, this alignment could be altered by the remaining code in `diff_lineMode_` hence we should call the `diff_cleanupSemantic` again at the end of the function.

The added tests demonstrate the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reviewable/diff/2)
<!-- Reviewable:end -->
